### PR TITLE
Update Consul key path for Cilium policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Cilium CNI is available.
 | ---------------------- | --------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------- |
 | `--cilium-cidr`, `-c`, | `NETREAP_CILIUM_CIDR` | None, this is a required flag | The CIDR block of the address space used by Cilium. This allows netreap to identify if a job is a Cilium one. |
 | `--debug`              | `NETREAP_DEBUG`       | `false`                       | Turns on debug logging                                                                                        |
-| `--policy-key`         | `NETREAP_POLICY_KEY`  | `netreap.io/netreap/policy`   | Consul key that Netreap watches for changes to the Cilium policy JSON value |
+| `--policy-key`         | `NETREAP_POLICY_KEY`  | `netreap.io/policy`           | Consul key that Netreap watches for changes to the Cilium policy JSON value |
 | `--exclude-tags`       | `NETREAP_EXCLUDE_TAG` | None                          | List of Consul service tags to use as a filter to exclude from Netreap |
 
 Please note that to configure the Nomad and Consul clients that Netreap uses,
@@ -235,7 +235,7 @@ Whenever you want to update policies in your cluster, simply set the key in
 Consul:
 
 ```bash
-consul kv put netreap.io/netreap/policy @policy.json
+consul kv put netreap.io/policy @policy.json
 ```
 
 Netreap automatically picks up any updates to the value and updates the policy


### PR DESCRIPTION
## Feature or Problem
Looks like there's a typo in the key path we use for reading the Cilium policies. It should be `netreap.io/policy`.
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

## Related Issues
<!---
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->


## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works
--->
