### PR TITLE
added codeowners file for review notifications

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Netreap authors
+@protochron @thomastaylor312


### PR DESCRIPTION
This PR adds the `CODEOWNERS` file, to make sure we notify @protochron and @thomastaylor312 when PRs come in.