### PR TITLE
Match Nomad Default for CNI Config Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ it does or if you want to change Docker's IP range, take a look at the
 ```
 
 You will then need to make sure you have a CNI configuration for Cilium in
-`/opt/cni/conf.d` named `cilium.conflist`:
+`/opt/cni/config` named `cilium.conflist`:
 
 ```json
 {


### PR DESCRIPTION
## Feature or Problem

By [default Nomad](https://developer.hashicorp.com/nomad/docs/networking/cni#cni-configuration-files) looks in `/opt/cni/config` for the CNI network configurations. This change updates the documentation to match.
