### PR TITLE
ci: Explicitly use Debian Bullseye-based Go image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 as builder
+FROM golang:1.20-bullseye as builder
 WORKDIR /netreap
 COPY . /netreap
 ARG VERSION


### PR DESCRIPTION
## Feature or Problem
It looks like the maintainers of the Go Docker image decided to switch to base their images off of Debian Bookworm instead of Bullseye. This meant that `golang-1.20` pulled an image with a newer version of glibc which only broke when trying to run the image.

This is a quick fix that explicitly calls for the Bullseye version of the build image.


## Related Issues
Closes #22, #16.
<!---
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->


## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works
--->
