### PR TITLE
Reduce load on Cilium API by filtering more events

### DIFF
--- a/reapers/endpoints_test.go
+++ b/reapers/endpoints_test.go
@@ -140,7 +140,7 @@ func TestEndpointReconcile(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			reaper, err := NewEndpointReaper(tt.cilium, tt.nomadAllocations, nil)
+			reaper, err := NewEndpointReaper(tt.cilium, tt.nomadAllocations, nil, "")
 			if err != nil {
 				t.Fatalf("unexpected error creating poller %v", err)
 			}


### PR DESCRIPTION
This feature reduces the API call rate to Cilium and tries to ensure netreap only makes calls when needed. This helps in high density scenarios to reduce the CIlium agent API overhead. This feature consists of three main changes:

1. The allocation events from Nomad include the NodeID where the allocation is assigned. We can use that to drop events early in processing by comparing the event NodeID with the local agent NodeID. This reduces the load on Cilium agents in the cluster as they are no longer queried about allocations that don't exist on the node.
2. netreap only needs to watch the `Allocation` event stream and can ignore events for terminal allocations. Nomad will handle cleaning up the endpoint in that case.
3. Only call the Cilium endpoint patch API if the labels to apply to the endpoint have actually changed. Cilium will do a full endpoint regeneration even if the labels are the same so only doing that on label change this greatly cuts down on load. 
