### PR TITLE
Switch from deprecated RunWithClientAndLogger to RunWithClientAndHclog

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/cilium/cilium v1.13.5
 	github.com/hashicorp/consul/api v1.18.0
+	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/nomad/api v0.0.0-20230719205936-8d2894699319
 	github.com/urfave/cli/v2 v2.11.2
 	go.uber.org/zap v1.23.0
@@ -46,7 +47,6 @@ require (
 	github.com/hashicorp/cronexpr v1.1.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-hclog v1.4.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-msgpack v1.1.5 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -291,8 +291,8 @@ github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtng
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
-github.com/hashicorp/go-hclog v1.4.0 h1:ctuWFGrhFha8BnnzxqeRGidlEcQkDyL5u8J8t5eA11I=
-github.com/hashicorp/go-hclog v1.4.0/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
+github.com/hashicorp/go-hclog v1.5.0 h1:bI2ocEMgcVlz55Oj1xZNBsVi900c7II+fWDyV9o+13c=
+github.com/hashicorp/go-hclog v1.5.0/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -9,6 +9,7 @@ import (
 	ciliumClient "github.com/cilium/cilium/pkg/client"
 	consulApi "github.com/hashicorp/consul/api"
 	consulWatch "github.com/hashicorp/consul/api/watch"
+	"github.com/hashicorp/go-hclog"
 	"go.uber.org/zap"
 )
 
@@ -99,8 +100,10 @@ func (p *Poller) Run(ctx context.Context) error {
 	}
 
 	go func() {
-		//lint:ignore SA1019 we need to fix this, but it requires adapting the zap logger
-		err := wp.RunWithClientAndLogger(p.consulClient, l)
+		hclogger := hclog.FromStandardLogger(l, &hclog.LoggerOptions{
+			Name: "policy_poller",
+		})
+		err := wp.RunWithClientAndHclog(p.consulClient, hclogger)
 		if err != nil {
 			zap.S().Error("error running watcher", zap.Error(err))
 		}


### PR DESCRIPTION
## Feature or Problem

I noticed that we were using a deprecated method, so I figured it might be better to switch to the supported method in order to stay on the supported path by making use of the [wrapping functionality provided by `hclog`](https://pkg.go.dev/github.com/hashicorp/go-hclog#FromStandardLogger) to satisfy the new method.

## Related Issues
<!---
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->


## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works
--->
