### PR TITLE
not shutdown netreap after getting incorrect event from nomad

### DIFF
--- a/reapers/endpoints.go
+++ b/reapers/endpoints.go
@@ -2,6 +2,7 @@ package reapers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"sort"
@@ -90,6 +91,10 @@ func (e *EndpointReaper) Run(ctx context.Context) (<-chan bool, error) {
 
 			case events := <-eventChan:
 				if events.Err != nil {
+					if _, ok := err.(*json.SyntaxError); ok {
+						zap.L().Debug("Got incorrect event from nomad", zap.Error(events.Err))
+						continue
+					}
 					zap.L().Debug("Got error message from node event channel", zap.Error(events.Err))
 					failChan <- true
 					return

--- a/reapers/endpoints.go
+++ b/reapers/endpoints.go
@@ -93,11 +93,11 @@ func (e *EndpointReaper) Run(ctx context.Context) (<-chan bool, error) {
 				if events.Err != nil {
 					if _, ok := err.(*json.SyntaxError); ok {
 						zap.L().Debug("Got incorrect event from nomad", zap.Error(events.Err))
-						continue
+					} else {
+						zap.L().Debug("Got error message from node event channel", zap.Error(events.Err))
+						failChan <- true
+						return
 					}
-					zap.L().Debug("Got error message from node event channel", zap.Error(events.Err))
-					failChan <- true
-					return
 				}
 
 				zap.L().Debug("Got events from Allocation topic. Handling...", zap.Int("event-count", len(events.Events)))


### PR DESCRIPTION
## Feature or Problem

Sometimes nomad sends events with errors, because nomad can't unmarshall to struct. In this case there is no problem in netreap, so it shouldn't shutdown after handling such events

## Related Issues
<!---
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->


## Consumer Impact

Netreap won't restart after this fix, it just skips such events

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones
--->

### Manual Verification
Just check type of error, if equal skip event
