### PR TITLE
Bridge Cilium log usage to zap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/hashicorp/consul/api v1.18.0
 	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/nomad/api v0.0.0-20230719205936-8d2894699319
+	github.com/sirupsen/logrus v1.9.2
 	github.com/urfave/cli/v2 v2.11.2
 	go.uber.org/zap v1.23.0
 )
@@ -88,7 +89,6 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sasha-s/go-deadlock v0.3.1 // indirect
 	github.com/shirou/gopsutil/v3 v3.23.1 // indirect
-	github.com/sirupsen/logrus v1.9.2 // indirect
 	github.com/spf13/afero v1.9.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/cobra v1.6.1 // indirect

--- a/internal/zaplogrus/zap_logrus_hook.go
+++ b/internal/zaplogrus/zap_logrus_hook.go
@@ -1,0 +1,71 @@
+package zaplogrus
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+type ZapLogrusHook struct {
+	logger *zap.Logger
+}
+
+func NewZapLogrusHook(logger *zap.Logger) *ZapLogrusHook {
+	return &ZapLogrusHook{
+		logger: logger,
+	}
+}
+
+func (h *ZapLogrusHook) Fire(entry *logrus.Entry) error {
+	zapLevel := h.zapLevel(entry.Level)
+	if zapLevel == zapcore.InvalidLevel {
+		return fmt.Errorf("unhandled logrus level %v", entry.Level)
+	}
+
+	if ce := h.logger.Check(zapLevel, entry.Message); ce != nil {
+		caller := entry.Caller
+
+		if caller != nil {
+			ce.Caller = zapcore.NewEntryCaller(caller.PC, caller.File, caller.Line, caller.PC != 0)
+		}
+
+		fields := make([]zap.Field, 0, len(entry.Data))
+
+		for key, value := range entry.Data {
+			if key == logrus.ErrorKey {
+				fields = append(fields, zap.Error(value.(error)))
+			} else {
+				fields = append(fields, zap.Any(key, value))
+			}
+		}
+
+		ce.Write(fields...)
+	}
+
+	return nil
+}
+
+func (h *ZapLogrusHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+func (h *ZapLogrusHook) zapLevel(level logrus.Level) zapcore.Level {
+	switch level {
+	case logrus.PanicLevel:
+		return zapcore.PanicLevel
+	case logrus.FatalLevel:
+		return zapcore.FatalLevel
+	case logrus.ErrorLevel:
+		return zapcore.ErrorLevel
+	case logrus.WarnLevel:
+		return zapcore.WarnLevel
+	case logrus.InfoLevel:
+		return zapcore.InfoLevel
+	case logrus.DebugLevel, logrus.TraceLevel:
+		return zapcore.DebugLevel
+	default:
+		return zapcore.InvalidLevel
+	}
+}

--- a/main.go
+++ b/main.go
@@ -3,17 +3,20 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"os/signal"
 
 	cilium_client "github.com/cilium/cilium/pkg/client"
+	cilium_logging "github.com/cilium/cilium/pkg/logging"
 	consul_api "github.com/hashicorp/consul/api"
 	nomad_api "github.com/hashicorp/nomad/api"
 	"github.com/urfave/cli/v2"
 	"go.uber.org/zap"
 
 	"github.com/cosmonic/netreap/internal/policy"
+	"github.com/cosmonic/netreap/internal/zaplogrus"
 	"github.com/cosmonic/netreap/reapers"
 )
 
@@ -62,6 +65,12 @@ func main() {
 				logger = devlog
 			}
 			zap.ReplaceGlobals(logger)
+
+			// Bridge Cilium logrus to netreap zap
+			cilium_logging.DefaultLogger.SetReportCaller(true)
+			cilium_logging.DefaultLogger.SetOutput(io.Discard)
+			cilium_logging.DefaultLogger.AddHook(zaplogrus.NewZapLogrusHook(logger))
+
 			return nil
 		},
 		Action: func(c *cli.Context) error {


### PR DESCRIPTION
Cilium uses logrus instead of zap for logging. This change introducs a simple bridge that should funnel any logs from the Cilium codebase through the zap logger in netreap.

This is part of breaking up #33.
