### PR TITLE
Move netreap specific labels to separate package.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-netreap
+./netreap
 .op

--- a/internal/netreap/netreap.go
+++ b/internal/netreap/netreap.go
@@ -1,0 +1,33 @@
+package netreap
+
+const (
+
+	// LabelKeyNomadJobID is the name of the policy label which refers to the
+	// Cilium policy name
+	LabelKeyCiliumPolicyName = "cilium.policy.name"
+
+	// LabelKeyNomadJobID is the Nomad Job ID
+	LabelKeyNomadJobID = "nomad.job_id"
+
+	// LabelKeyNomadJobID is the Nomad Namespace of the job
+	LabelKeyNomadNamespace = "nomad.namespace"
+
+	// LabelKeyNomadTaskGroupID is the Nomad task group of the job allocation
+	LabelKeyNomadTaskGroupID = "nomad.task_group_id"
+
+	// LabelSourceNetreap is a label imported from Netreap
+	LabelSourceNetreap = "netreap"
+
+	// LabelSourceNomadKeyPrefix is prefix of a Netreap label
+	LabelSourceNetreapKeyPrefix = LabelSourceNetreap + "."
+
+	// LabelSourceNomad is a label imported from Nomad
+	LabelSourceNomad = "nomad"
+
+	// LabelSourceNomadKeyPrefix is prefix of a Nomad label
+	LabelSourceNomadKeyPrefix = LabelSourceNomad + "."
+)
+
+var (
+	LabelCiliumPolicyName = LabelKeyCiliumPolicyName + "." + LabelSourceNetreap
+)


### PR DESCRIPTION
This change is mostly here to mirror how Cilium structures its code internally. No functional change.
