### PR TITLE
fix: check to see if endpoint is nil before appending the ID in an error

### DIFF
--- a/reapers/endpoints.go
+++ b/reapers/endpoints.go
@@ -222,8 +222,10 @@ func (e *EndpointReaper) handleAllocationUpdated(event nomad_api.Event) {
 		fields := []zap.Field{zap.String("event-type", event.Type),
 			zap.Uint64("event-index", event.Index),
 			zap.String("container-id", allocation.ID),
-			zap.Int64("endpoint-id", endpoint.ID),
 			zap.Error(err),
+		}
+		if endpoint != nil {
+			fields = append(fields, zap.Int64("endpoint-id", endpoint.ID))
 		}
 		if strings.Contains(err.Error(), "getEndpointIdNotFound") {
 			// This is fine, the endpoint probably just isn't on this host


### PR DESCRIPTION
## Feature or Problem
It looks like if an endpoint isn't found we might not always be able to get its ID when logging an error. This caused a panic when it should not have.
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

## Related Issues
Closes #38.
<!---
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->


## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works
--->
