### PR TITLE
Add ability to specify list of ignored Nomad meta labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,10 +234,11 @@ clients are available to Netreap.
 
 ### Configuring
 
-| Flag                   | Env Var               | Default                       | Description                                                                                                   |
-| ---------------------- | --------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `--debug`              | `NETREAP_DEBUG`       | `false`                       | Turns on debug logging                                                                                        |
-| `--policy-key`         | `NETREAP_POLICY_KEY`  | `netreap.io/policy`           | Consul key that Netreap watches for changes to the Cilium policy JSON value |
+| Flag                         | Env Var                        | Default                       | Description                                                                                                   |
+| ---------------------------- | ------------------------------ | ----------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `--debug`                    | `NETREAP_DEBUG`                | `false`                       | Turns on debug logging                                                                                        |
+| `--policy-key`               | `NETREAP_POLICY_KEY`           | `netreap.io/policy`           | Consul key that Netreap watches for changes to the Cilium policy JSON value                                   |
+| `--ignore-nomad-meta-labels` | `NETREAP_IGNORED_META_LABELS`  | `""`                          | Comma-separated list of Nomad's job metadata that not will be passed to Cilium Endpoint labels                |
 
 Please note that to configure the Nomad, Consul and Cilium clients that Netreap uses,
 we leverage the well defined environment variables for

--- a/internal/netreap/netreap.go
+++ b/internal/netreap/netreap.go
@@ -31,3 +31,7 @@ const (
 var (
 	LabelCiliumPolicyName = LabelKeyCiliumPolicyName + "." + LabelSourceNetreap
 )
+
+type IgnoredLabels struct {
+	IgnoreMeta []string
+}

--- a/reapers/endpoints_test.go
+++ b/reapers/endpoints_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	endpoint_id "github.com/cilium/cilium/pkg/endpoint/id"
+	"github.com/cosmonic-labs/netreap/internal/netreap"
 	nomad_api "github.com/hashicorp/nomad/api"
 )
 
@@ -140,7 +141,7 @@ func TestEndpointReconcile(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			reaper, err := NewEndpointReaper(tt.cilium, tt.nomadAllocations, nil, "")
+			reaper, err := NewEndpointReaper(tt.cilium, tt.nomadAllocations, nil, "", netreap.IgnoredLabels{})
 			if err != nil {
 				t.Fatalf("unexpected error creating poller %v", err)
 			}


### PR DESCRIPTION
## Feature or Problem

We are actively using Nomad for developments and testing apps and push various deployment info to Nomad's meta such as time of deployment, author, pipeline id and other similar things that help to identify exact revision.  
This leads to huge amount of unique labels on Cilium that creates new Identity for them exhausting free identities very fast.  
New option provides ability to ignore specified metadata keys when Netreap labeling Cilium endpoints.

## Related Issues
<!---
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->


## Consumer Impact
Can reduce amount of identities created by Cilium.  
Without specifying any values Netreap behaviour won't change.

## Testing

Built on platform(s)
- [x] x86_64-linux

Tested on platform(s)
- [x] x86_64-linux

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works
--->
Built changed version without new parameter/env var, deployed to Nomad. Behaviour didn't change.
Specified some values for env var, that label absent from Cilium.